### PR TITLE
refactor: use Promise.all

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-const path = require("path");
-const visit = require("unist-util-visit");
-const upload = require("./upload");
-const getImageUrl = require("./build-url");
+const path = require('path');
+const visit = require('unist-util-visit');
+const upload = require('./upload');
+const getImageUrl = require('./build-url');
 
 module.exports = ({
   baseDir,
-  uploadFolder = "netlify",
-  transformations = "f_auto,q_auto",
+  uploadFolder = 'netlify',
+  transformations = 'f_auto,q_auto',
 }) => async (tree) => {
   let promises = [];
 
@@ -40,13 +40,13 @@ module.exports = ({
         .join();
 
       // for browsers that support native lazy loading, add it
-      node.properties.loading = "lazy";
+      node.properties.loading = 'lazy';
     });
 
     promises.push(promise);
   };
 
-  visit(tree, (node) => node.tagName === "img", convertToCloudinary);
+  visit(tree, (node) => node.tagName === 'img', convertToCloudinary);
   await Promise.all(promises);
 
   return;

--- a/index.js
+++ b/index.js
@@ -14,12 +14,10 @@ module.exports = ({
     const imagePath = path.join(baseDir, node.properties.src);
 
     // upload the local image to Cloudinary
-    const p = upload({
+    const promise = upload({
       imagePath,
       uploadFolder,
     }).then((cloudinaryName) => {
-      console.log({ cloudinaryName });
-
       // replace the local image path with the Cloudinary asset URL
       node.properties.src = getImageUrl({
         fileName: cloudinaryName,
@@ -45,7 +43,7 @@ module.exports = ({
       node.properties.loading = "lazy";
     });
 
-    promises.push(p);
+    promises.push(promise);
   };
 
   visit(tree, (node) => node.tagName === "img", convertToCloudinary);


### PR DESCRIPTION
The async code was being finicky, so I rewrote it to collect a bunch of promises using `visit` and then do an `await Promise.all` call to execute everything before exiting