### PR TITLE
Only upload images that don't already exist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,11 @@
       "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
       "integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg=="
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "cloudinary": "^1.18.1",
     "dotenv": "^8.2.0",
     "md5-file": "^4.0.0",
+    "node-fetch": "^2.6.1",
     "unist-util-visit": "^2.0.1"
   }
 }

--- a/upload.js
+++ b/upload.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const path = require('path');
 const fileHash = require('md5-file');
 const cloudinary = require('cloudinary').v2;
+const fetch = require('node-fetch')
 
 module.exports = async ({ imagePath, uploadFolder }) => {
   const { name } = path.parse(imagePath);
@@ -14,11 +15,15 @@ module.exports = async ({ imagePath, uploadFolder }) => {
     api_secret: process.env.CLOUDINARY_API_SECRET,
   });
 
-  await cloudinary.uploader.upload(imagePath, {
-    public_id,
-    folder: uploadFolder,
-    overwrite: false,
-  });
+  const resp = await fetch(cloudinary.url(`${uploadFolder}/${public_id}`), { method: 'HEAD' })
+
+  if (resp.status !== 200) {
+    await cloudinary.uploader.upload(imagePath, {
+      public_id,
+      folder: uploadFolder,
+      overwrite: false,
+    });
+  }
 
   return public_id;
 };


### PR DESCRIPTION
This update adds in a `HEAD` http request to check if the file exists already on Cloudinary and if it does, skip over the `upload` call which speeds up the performance of the plugin.

For example, my site which has ~50 MDX pages and 1-2 images per page on average currently takes around 8 seconds to build. With this change, It is reduced down to around 3 seconds.